### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="stylesheet.css" rel="stylesheet" type="text/css">
         <title> Etch-A-Sketch </title>
     </head>

--- a/script.js
+++ b/script.js
@@ -1,14 +1,13 @@
-let auto = "auto ";
-let final = auto.repeat(16);
-document.getElementById("grid").style.gridTemplateColumns = final;
-for(let i = (16*16); i != 0; i --){
+let globalGridSize = 16;
+document.getElementById("grid").style.gridTemplateColumns = `repeat(${globalGridSize}, 1fr)`;
+document.getElementById("grid").style.gridTemplateRows = `repeat(${globalGridSize}, 1fr)`;
+for(let i = (globalGridSize*globalGridSize); i != 0; i --){
     let divs = document.createElement("div");
     divs.className = "gridBlock";
     divs.addEventListener("mouseover",toggle);
     document.getElementById("grid").appendChild(divs);
 }
 
-let globalGridSize = 16;
 
 // Buttons 
 
@@ -25,9 +24,8 @@ function eraser(){
     while(grid.hasChildNodes()){
         grid.removeChild(grid.firstChild);
     }
-    let auto = "auto ";
-    let final = auto.repeat(globalGridSize);
-    document.getElementById("grid").style.gridTemplateColumns = final;
+    document.getElementById("grid").style.gridTemplateColumns = `repeat(${globalGridSize}, 1fr)`;
+    document.getElementById("grid").style.gridTemplateRows = `repeat(${globalGridSize}, 1fr)`;
     for(let i = (globalGridSize*globalGridSize); i != 0; i --){
         let divs = document.createElement("div");
         divs.className = "gridBlock";
@@ -58,9 +56,8 @@ function gridCreator(){
             gridSize = 250;
         }
         globalGridSize = gridSize;
-        let auto = "auto ";
-        let final = auto.repeat(gridSize);
-        document.getElementById("grid").style.gridTemplateColumns = final;
+        document.getElementById("grid").style.gridTemplateColumns = `repeat(${gridSize}, 1fr)`;
+        document.getElementById("grid").style.gridTemplateRows = `repeat(${gridSize}, 1fr)`;
         for(let i = (gridSize*gridSize); i != 0; i --){
             let divs = document.createElement("div");
             divs.className = "gridBlock";

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,53 +1,56 @@
 #grid {
     background-color: lightgrey;
     display: grid;
-    position: absolute;
-    padding: 0px;
-    border-color: black;
-    border-style: solid;
-    border-width: 5px;
-    margin: 0px;
-    height: 500px;
-    width: 500px;
-    left: 35%;
-    top: 15%;
+    padding: 0;
+    border: 5px solid black;
+    margin: 1rem auto;
+    width: min(90vmin, 500px);
+    height: min(90vmin, 500px);
 }
 
 .gridBlock{
-    border: 0px;
-    padding: 0px;
+    border: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
 }
 
 .gridBlockOn {
     background-color: black;
-    border: 0px;
-    padding: 0px;
+    border: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
 }
 
 #btns{
-    position: absolute;
-    top: 5%;
-    left: 48%;
+    display: flex;
+    gap: 1rem;
+    margin: 1rem 0;
 }
 
 body {
     background-color: lightgreen;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
 }
 .draw {
     position: absolute;
-    font-size: 800%;
-    top: 10%;
+    font-size: 8vw;
+    top: 5vh;
     text-orientation: sideways;
     writing-mode: vertical-rl;
-    left: 5%;
 }
 
 #left {
-    top: 10%;
-    left: 5%;
+    top: 5vh;
+    left: 2vw;
 }
 
 #right {
-    top: 10%;
-    right: 3%;
+    top: 5vh;
+    right: 2vw;
 }


### PR DESCRIPTION
## Summary
- make Etch-A-Sketch responsive by using flexbox and viewport units
- add viewport meta tag
- use `repeat(n, 1fr)` for grid sizing and square blocks

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68840898e3248326af24e7fc3f1b6288