### PR TITLE
Improve Etch-A-Sketch with responsive modern styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,18 +1,20 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <link href="stylesheet.css" rel="stylesheet" type="text/css">
-        <title> Etch-A-Sketch </title>
-    </head>
-    <body>
-        <h1 id="left" class="draw"> DRAW!!</h1>
-        <h1 id="right" class="draw"> DRAW!!</h1>
-        <div id="btns">
-        <button id="size"> Get New Canvas </button>
-        <button id="erase"> Clear </button>
-        </div>
-        <div id="grid">
-        </div>
-    </body>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="stylesheet.css" rel="stylesheet" type="text/css" />
+    <title>Etch-A-Sketch</title>
+  </head>
+  <body>
+    <header>
+      <h1 class="title">Etch-A-Sketch</h1>
+      <div id="btns">
+        <button id="size">Get New Canvas</button>
+        <button id="erase">Clear</button>
+      </div>
+    </header>
+    <div id="grid"></div>
     <script src="script.js" type="text/javascript"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -68,3 +68,4 @@ function gridCreator(){
             document.getElementById("grid").appendChild(divs);
         }
 }
+

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,53 +1,73 @@
-#grid {
-    background-color: lightgrey;
-    display: grid;
-    position: absolute;
-    padding: 0px;
-    border-color: black;
-    border-style: solid;
-    border-width: 5px;
-    margin: 0px;
-    height: 500px;
-    width: 500px;
-    left: 35%;
-    top: 15%;
-}
-
-.gridBlock{
-    border: 0px;
-    padding: 0px;
-}
-
-.gridBlockOn {
-    background-color: black;
-    border: 0px;
-    padding: 0px;
-}
-
-#btns{
-    position: absolute;
-    top: 5%;
-    left: 48%;
+* {
+  box-sizing: border-box;
 }
 
 body {
-    background-color: lightgreen;
-}
-.draw {
-    position: absolute;
-    font-size: 800%;
-    top: 10%;
-    text-orientation: sideways;
-    writing-mode: vertical-rl;
-    left: 5%;
-}
-
-#left {
-    top: 10%;
-    left: 5%;
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #a8edea, #fed6e3);
+  font-family: system-ui, sans-serif;
 }
 
-#right {
-    top: 10%;
-    right: 3%;
+.title {
+  margin-bottom: 1rem;
+  color: #333;
+}
+
+#btns {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #333;
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+button:hover {
+  background-color: #555;
+  transform: translateY(-2px);
+}
+
+#grid {
+  display: grid;
+  width: 80vmin;
+  height: 80vmin;
+  max-width: 600px;
+  max-height: 600px;
+  border: 5px solid #333;
+  border-radius: 10px;
+  background-color: #fff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.gridBlock,
+.gridBlockOn {
+  aspect-ratio: 1/1;
+}
+
+.gridBlock {
+  background-color: transparent;
+}
+
+.gridBlockOn {
+  background-color: #333;
+}
+
+@media (max-width: 600px) {
+  button {
+    font-size: 0.9rem;
+    padding: 0.4rem 0.8rem;
+  }
 }


### PR DESCRIPTION
## Summary
- Replace absolute layout with responsive flexbox structure and centered grid
- Add meta viewport and refreshed index markup
- Apply modern gradient background, styled buttons, and scalable grid cells

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b651b1cfe8832699071dd402951a43