### PR TITLE
Replace prompt with styled modal for grid size

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,19 @@
       </div>
     </header>
     <div id="grid"></div>
+
+    <div id="modal" class="modal hidden">
+      <div class="modal-content">
+        <h2>New Canvas</h2>
+        <label for="grid-size-input">Grid size (max 250):</label>
+        <input type="number" id="grid-size-input" min="1" max="250" />
+        <div class="modal-buttons">
+          <button id="modal-confirm">Create</button>
+          <button id="modal-cancel">Cancel</button>
+        </div>
+      </div>
+    </div>
+
     <script src="script.js" type="text/javascript"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,71 +1,54 @@
-let auto = "auto ";
-let final = auto.repeat(16);
-document.getElementById("grid").style.gridTemplateColumns = final;
-for(let i = (16*16); i != 0; i --){
-    let divs = document.createElement("div");
-    divs.className = "gridBlock";
-    divs.addEventListener("mouseover",toggle);
-    document.getElementById("grid").appendChild(divs);
-}
-
-let globalGridSize = 16;
-
-// Buttons 
-
-document.getElementById("size").addEventListener("click",gridCreator);
-document.getElementById("erase").addEventListener("click",eraser);
-//Functions
-
 function toggle(){
     this.className = "gridBlockOn";
 }
 
-function eraser(){
+let globalGridSize = 16;
+createGrid(globalGridSize);
+
+document.getElementById("size").addEventListener("click", openModal);
+document.getElementById("erase").addEventListener("click", eraser);
+document.getElementById("modal-confirm").addEventListener("click", applyGridSize);
+document.getElementById("modal-cancel").addEventListener("click", closeModal);
+
+function createGrid(gridSize){
+    globalGridSize = gridSize;
     let grid = document.getElementById("grid");
     while(grid.hasChildNodes()){
         grid.removeChild(grid.firstChild);
     }
     let auto = "auto ";
-    let final = auto.repeat(globalGridSize);
-    document.getElementById("grid").style.gridTemplateColumns = final;
-    for(let i = (globalGridSize*globalGridSize); i != 0; i --){
+    let final = auto.repeat(gridSize);
+    grid.style.gridTemplateColumns = final;
+    for(let i = (gridSize*gridSize); i != 0; i--){
         let divs = document.createElement("div");
         divs.className = "gridBlock";
-        divs.addEventListener("mouseover",toggle);
-        document.getElementById("grid").appendChild(divs);
+        divs.addEventListener("mouseover", toggle);
+        grid.appendChild(divs);
     }
 }
 
-function gridCreator(){
-    let grid = document.getElementById("grid");
-    while(grid.hasChildNodes()){
-        grid.removeChild(grid.firstChild);
-    }
-    let gridSize = 16;
-    gridSize = prompt("Grid Size: ");
-    if(gridSize === ""){
+function eraser(){
+    createGrid(globalGridSize);
+}
+
+function openModal(){
+    document.getElementById("grid-size-input").value = "";
+    document.getElementById("modal").classList.remove("hidden");
+}
+
+function closeModal(){
+    document.getElementById("modal").classList.add("hidden");
+}
+
+function applyGridSize(){
+    let input = document.getElementById("grid-size-input");
+    let gridSize = parseInt(input.value);
+    if(isNaN(gridSize) || gridSize <= 0){
         gridSize = 16;
-    } else if(gridSize == null){
-        gridSize = 16;
+    } else if(gridSize > 250){
+        gridSize = 250;
     }
-    while(isNaN(gridSize)){
-        alert("Please Enter A number");
-        gridSize = prompt("Grid Size: ");    
-        }
-        gridSize = Math.round(gridSize);
-        if(gridSize > 250){
-            alert("250 by 250 is the largest grid size so it has been set to that");
-            gridSize = 250;
-        }
-        globalGridSize = gridSize;
-        let auto = "auto ";
-        let final = auto.repeat(gridSize);
-        document.getElementById("grid").style.gridTemplateColumns = final;
-        for(let i = (gridSize*gridSize); i != 0; i --){
-            let divs = document.createElement("div");
-            divs.className = "gridBlock";
-            divs.addEventListener("mouseover",toggle);
-            document.getElementById("grid").appendChild(divs);
-        }
+    closeModal();
+    createGrid(gridSize);
 }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -89,6 +89,11 @@ button:hover {
   z-index: 1000;
 }
 
+.modal.hidden {
+  display: none;
+}
+
+
 .modal-content {
   background-color: #fff;
   padding: 2rem;

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -71,3 +71,44 @@ button:hover {
     padding: 0.4rem 0.8rem;
   }
 }
+
+.hidden {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: #fff;
+  padding: 2rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: center;
+}
+
+.modal-content input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.modal-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary
- Replace browser prompt with modal interface for choosing grid size
- Style modal to match existing theme and provide create/cancel controls
- Simplify grid creation logic and reuse for erasing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d14ea59883269767b7af243a3d5f